### PR TITLE
helm chart within the repository for k8s-bioc-redis-example

### DIFF
--- a/helm-chart/.helmignore
+++ b/helm-chart/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Bioconductor RedisParam using Rstudio
+name: k8s-redis-bioc-chart
+version: 0.1.0
+maintainers:
+  - name: Nitesh Turaga

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -1,0 +1,27 @@
+# README
+
+## INSTALL helm chart
+
+Clone and install the helm chart to get going with the Bioc RedisParam on K8s.
+
+### Quickstart
+
+	git clone https://github.com/nturaga/k8s-redis-bioc-chart.git
+
+	helm install k8s-redis-bioc-chart
+
+### Requirements
+
+1. Kubernetes cluster is running, i.e (either minikube on your local
+   machine or a cluster in the cloud)
+   
+   This should work
+   
+		kubectl cluster-info 
+	
+		minikube start ## if you want to start a cluster
+
+
+1. Have helm installed!! 
+
+		brew install helm 

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -6,9 +6,21 @@ Clone and install the helm chart to get going with the Bioc RedisParam on K8s.
 
 ### Quickstart
 
-	git clone https://github.com/nturaga/k8s-redis-bioc-chart.git
+Clone the repo
 
-	helm install k8s-redis-bioc-chart
+	git clone https://github.com/mtmorgan/k8s-redis-bioc-example.git
+
+Install the helm chart
+
+	helm install k8s-redis-bioc-example/helm-chart/
+	
+Get list of running helm charts
+
+	helm list <release name>
+
+Get status of the installed chart
+
+	helm status <release name>
 
 ### Requirements
 
@@ -21,7 +33,18 @@ Clone and install the helm chart to get going with the Bioc RedisParam on K8s.
 	
 		minikube start ## if you want to start a cluster
 
-
 1. Have helm installed!! 
 
 		brew install helm 
+
+### Debug or dry run
+
+Very useful options to check how the templates are forming,
+
+`--dry-run` doesn't actually install the chart and run it.
+
+	helm install --dry-run k8s-redis-bioc-example/helm-chart/
+
+`--debug` prints out the templates with the values.yaml embedded in them
+
+	helm install --dry-run --debug k8s-redis-bioc-example/helm-chart/

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -48,3 +48,24 @@ Very useful options to check how the templates are forming,
 `--debug` prints out the templates with the values.yaml embedded in them
 
 	helm install --dry-run --debug k8s-redis-bioc-example/helm-chart/
+
+### User Settings
+
+The defined user settings in the values.yaml file of the helm chart,
+can be changed in two ways,
+
+1. In the values.yaml file directly, where you can modify the Rstudio
+   login password ``rstudioPassword`` and the number of workers you
+   want to deploy `workerPoolSize`
+
+		# user settings
+		userSettings:
+        # User setting: change the rstudio password on the manager
+	       rstudioPassword: bioc
+	    # User setting: change the number of workers in your cluster
+	       workerPoolSize: 5
+		   
+1. The other way is while deploying the helm chart,
+
+		helm install k8s-redis-bioc-example/helm-chart/ \
+			--set userSettings.rstudioPassword=biocuser,userSettings.workerPoolSize=10 

--- a/helm-chart/templates/manager-pod.yaml
+++ b/helm-chart/templates/manager-pod.yaml
@@ -10,8 +10,8 @@ spec:
       image: {{ .Values.cluster.managerImage}}
       tag: {{ .Values.cluster.managerImageTag }}
       env:
-        - name: {{ .Values.managerConfig.env.name}}
-          value: {{ .Values.managerConfig.env.value}}
+        - name: PASSWORD
+          value: {{ .Values.userSettings.rstudioPassword}}
       ports:
         - containerPort: {{ .Values.managerConfig.containerPort}}
       command: ["/init"]

--- a/helm-chart/templates/manager-pod.yaml
+++ b/helm-chart/templates/manager-pod.yaml
@@ -8,10 +8,12 @@ spec:
   containers:
     - name: manager
       image: {{ .Values.cluster.managerImage}}
+      tag: {{ .Values.cluster.managerImageTag }}
       env:
         - name: {{ .Values.managerConfig.env.name}}
           value: {{ .Values.managerConfig.env.value}}
       ports:
         - containerPort: {{ .Values.managerConfig.containerPort}}
       command: ["/init"]
+      imagePullPolicy: {{ .Values.managerConfig.pullPolicy }}
   restartPolicy: {{ .Values.clusterConfig.restartPolicy | quote }}

--- a/helm-chart/templates/manager-pod.yaml
+++ b/helm-chart/templates/manager-pod.yaml
@@ -1,19 +1,17 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name:  {{ .Release.Name }}-manager
+  name: {{ .Release.Name}}-manager
   labels:
     app: rstudio
 spec:
   containers:
     - name: manager
       image: {{ .Values.cluster.managerImage}}
-      tag: {{ .Values.cluster.managerImageTag}}
       env:
         - name: {{ .Values.managerConfig.env.name}}
-          value: {{ quote .Values.managerConfig.env.value}}
+          value: {{ .Values.managerConfig.env.value}}
       ports:
         - containerPort: {{ .Values.managerConfig.containerPort}}
       command: ["/init"]
-      imagePullPolicy: {{ .Values.managerConfig.pullPolicy}}
-  restartPolicy: {{ .Values.clusterConfig.restartPolicy}}
+  restartPolicy: "OnFailure"

--- a/helm-chart/templates/manager-pod.yaml
+++ b/helm-chart/templates/manager-pod.yaml
@@ -14,4 +14,4 @@ spec:
       ports:
         - containerPort: {{ .Values.managerConfig.containerPort}}
       command: ["/init"]
-  restartPolicy: "OnFailure"
+  restartPolicy: {{ .Values.clusterConfig.restartPolicy | quote }}

--- a/helm-chart/templates/manager-pod.yaml
+++ b/helm-chart/templates/manager-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name:  {{ .Release.Name }}-manager
+  labels:
+    app: rstudio
+spec:
+  containers:
+    - name: manager
+      image: {{ .Values.cluster.managerImage}}
+      tag: {{ .Values.cluster.managerImageTag}}
+      env:
+        - name: {{ .Values.managerConfig.env.name}}
+          value: {{ quote .Values.managerConfig.env.value}}
+      ports:
+        - containerPort: {{ .Values.managerConfig.containerPort}}
+      command: ["/init"]
+      imagePullPolicy: {{ .Values.managerConfig.pullPolicy}}
+  restartPolicy: {{ .Values.clusterConfig.restartPolicy}}

--- a/helm-chart/templates/redis-pod.yaml
+++ b/helm-chart/templates/redis-pod.yaml
@@ -6,10 +6,10 @@ metadata:
     app: redis
 spec:
   containers:
-    - name: redis-master
-      image: redis
+    - name: master
+      image: {{ .Values.cluster.redisImage}}
       env:
-        - name: {{ .Values.workerConfig.env.name | lower }}
-          value: {{ .Values.workerConfig.env.value | quote}}
+        - name: MASTER
+          value: "true"
       ports:
         - containerPort: {{ .Values.workerConfig.containerPort}}

--- a/helm-chart/templates/redis-pod.yaml
+++ b/helm-chart/templates/redis-pod.yaml
@@ -8,8 +8,10 @@ spec:
   containers:
     - name: master
       image: {{ .Values.cluster.redisImage}}
+      tag: {{ .Values.cluster.redisImageTag}}
       env:
         - name: {{ .Values.workerConfig.env.name | upper}}
           value: {{ .Values.workerConfig.env.value | quote }}
       ports:
         - containerPort: {{ .Values.workerConfig.containerPort}}
+      imagePullPolicy: {{ .Values.workerConfig.pullPolicy }}

--- a/helm-chart/templates/redis-pod.yaml
+++ b/helm-chart/templates/redis-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name}}-redis-master
+  labels:
+    app: redis
+spec:
+  containers:
+    - name: redis-master
+      image: redis
+      env:
+        - name: {{ .Values.workerConfig.env.name | lower }}
+          value: {{ .Values.workerConfig.env.value | quote}}
+      ports:
+        - containerPort: {{ .Values.workerConfig.containerPort}}

--- a/helm-chart/templates/redis-pod.yaml
+++ b/helm-chart/templates/redis-pod.yaml
@@ -9,7 +9,7 @@ spec:
     - name: master
       image: {{ .Values.cluster.redisImage}}
       env:
-        - name: MASTER
-          value: "true"
+        - name: {{ .Values.workerConfig.env.name | upper}}
+          value: {{ .Values.workerConfig.env.value | quote }}
       ports:
         - containerPort: {{ .Values.workerConfig.containerPort}}

--- a/helm-chart/templates/redis-service.yaml
+++ b/helm-chart/templates/redis-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name}}-redis
+  name: redis
 spec:
   ports:
     - port: {{ .Values.workerConfig.containerPort}}

--- a/helm-chart/templates/redis-service.yaml
+++ b/helm-chart/templates/redis-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name}}-redis
+spec:
+  ports:
+    - port: {{ .Values.workerConfig.containerPort}}
+      targetPort: {{ .Values.workerConfig.containerPort}}
+  selector:
+    app: redis

--- a/helm-chart/templates/rstudio-service.yaml
+++ b/helm-chart/templates/rstudio-service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - port: {{ .Values.rstudioConfig.port}}
       nodePort: {{ .Values.rstudioConfig.nodePort}}
-      name: http
+      name: {{ .Values.rstudioConfig.protocol }}
   selector:
     app: rstudio

--- a/helm-chart/templates/rstudio-service.yaml
+++ b/helm-chart/templates/rstudio-service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - port: {{ .Values.rstudioConfig.port}}
       nodePort: {{ .Values.rstudioConfig.nodePort}}
-      name: {{.Values.rstudioConfig.protocol}}
+      name: http
   selector:
     app: rstudio

--- a/helm-chart/templates/rstudio-service.yaml
+++ b/helm-chart/templates/rstudio-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name}}-rstudio
+  labels:
+    app: rstudio
+spec:
+  type: {{ .Values.rstudioConfig.type}}
+  ports:
+    - port: {{ .Values.rstudioConfig.port}}
+      nodePort: {{ .Values.rstudioConfig.nodePort}}
+      name: {{.Values.rstudioConfig.protocol}}
+  selector:
+    app: rstudio

--- a/helm-chart/templates/worker-jobs.yaml
+++ b/helm-chart/templates/worker-jobs.yaml
@@ -3,14 +3,14 @@ kind: Job
 metadata:
   name: worker
 spec:
-  parallelism: 5
+  parallelism: {{ .Values.workerConfig.workerPoolSize}}
   template:
     metadata:
       name: worker
     spec:
       containers:
       - name: worker
-        image: mtmorgan/bioc-redis-worker
+        image: {{ .Values.cluster.workerImage }}
         command: ["R"]
         args: ["-f", "/home/docker/worker.R"]
-      restartPolicy: OnFailure
+      restartPolicy: {{ .Values.clusterConfig.restartPolicy }}

--- a/helm-chart/templates/worker-jobs.yaml
+++ b/helm-chart/templates/worker-jobs.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: worker
 spec:
-  parallelism: {{ .Values.workerConfig.workerPoolSize}}
+  parallelism: {{ .Values.userSettings.workerPoolSize}}
   template:
     metadata:
       name: worker

--- a/helm-chart/templates/worker-jobs.yaml
+++ b/helm-chart/templates/worker-jobs.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name}}-worker
+spec:
+  parallelism: {{ .Values.workerConfig.workerPoolSize }}
+  template:
+    metadata:
+      name: worker
+    spec:
+      containers:
+      - name: worker
+        image: {{ .Values.cluster.workerImage}}
+        tag: {{ .Values.cluster.workerImageTag}}
+        command: ["R"]
+        args: ["-f", "/home/rstudio/worker.R"]
+        imagePullPolicy: IfNotPresent
+      restartPolicy: {{ .Values.clusterConfig.restartPolicy}}

--- a/helm-chart/templates/worker-jobs.yaml
+++ b/helm-chart/templates/worker-jobs.yaml
@@ -1,18 +1,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name}}-worker
+  name: worker
 spec:
-  parallelism: {{ .Values.workerConfig.workerPoolSize }}
+  parallelism: 5
   template:
     metadata:
       name: worker
     spec:
       containers:
       - name: worker
-        image: {{ .Values.cluster.workerImage}}
-        tag: {{ .Values.cluster.workerImageTag}}
+        image: mtmorgan/bioc-redis-worker
         command: ["R"]
-        args: ["-f", "/home/rstudio/worker.R"]
-        imagePullPolicy: IfNotPresent
-      restartPolicy: {{ .Values.clusterConfig.restartPolicy}}
+        args: ["-f", "/home/docker/worker.R"]
+      restartPolicy: OnFailure

--- a/helm-chart/templates/worker-jobs.yaml
+++ b/helm-chart/templates/worker-jobs.yaml
@@ -11,6 +11,8 @@ spec:
       containers:
       - name: worker
         image: {{ .Values.cluster.workerImage }}
+        tag: {{ .Values.cluster.workerImageTag }}
         command: ["R"]
         args: ["-f", "/home/docker/worker.R"]
+        imagePullPolicy: {{ .Values.workerConfig.pullPolicy }}
       restartPolicy: {{ .Values.clusterConfig.restartPolicy }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,0 +1,51 @@
+# Default values for k8s-redis-bioc-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Manager and worker images
+cluster:
+  # manager image
+  managerImage: mtmorgan/bioc-redis-manager
+  managerImageTag: latest
+  # worker image
+  workerImage: mtmorgan/bioc-redis-worker
+  workerImageTag: latest
+  # Rstudio image
+  rstudioImage: rocker/rstudio
+  rstudioTag: 3.6.0
+  # redis image
+  redisImage: redis
+  
+# Default cluster config:
+# settings here will apply to all three images,
+# manager, worker, rstudio
+clusterConfig:
+  restartPolicy: OnFailure
+
+# manager config
+managerConfig:
+  env:
+    name: PASSWORD
+    value: bioc
+  containerPort: 8787
+  pullPolicy: IfNotPresent
+
+# worker config
+workerConfig:
+  workerPoolSize: 5
+  env:
+    name: master
+    value: true
+  containerPort: 6379
+  pullPolicy: IfNotPresent
+
+# Rstudio specific config
+rstudioConfig:
+  env:
+    name: PASSWORD
+    value: bioc
+  type: NodePort
+  port: 8787
+  nodePort: 30001
+  protocol: http
+  pullPolicy: IfNotPresent

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -11,7 +11,8 @@ cluster:
   rstudioImage: rocker/rstudio
   rstudioTag: 3.6.0
   redisImage: redis
-  
+  redisImageTag: latest
+
 # Default cluster config:
 # settings here will apply to all three images,
 # manager, worker, rstudio
@@ -22,12 +23,14 @@ clusterConfig:
 managerConfig:
   env:
     name: PASSWORD
+    ## User setting: change the password of your Rstudio image
     value: bioc
   containerPort: 8787
   pullPolicy: IfNotPresent
 
 # worker config
 workerConfig:
+  ## User setting: change the numebr of workers in your cluster
   workerPoolSize: 5
   env:
     name: master

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -4,16 +4,12 @@
 
 # Manager and worker images
 cluster:
-  # manager image
   managerImage: mtmorgan/bioc-redis-manager
   managerImageTag: latest
-  # worker image
   workerImage: mtmorgan/bioc-redis-worker
   workerImageTag: latest
-  # Rstudio image
   rstudioImage: rocker/rstudio
   rstudioTag: 3.6.0
-  # redis image
   redisImage: redis
   
 # Default cluster config:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -4,12 +4,16 @@
 
 # Manager and worker images
 cluster:
+  # custom manager image
   managerImage: mtmorgan/bioc-redis-manager
   managerImageTag: latest
+  # custom worker image
   workerImage: mtmorgan/bioc-redis-worker
   workerImageTag: latest
+  # Rstudio image
   rstudioImage: rocker/rstudio
   rstudioTag: 3.6.0
+  # Redis image
   redisImage: redis
   redisImageTag: latest
 
@@ -21,17 +25,11 @@ clusterConfig:
 
 # manager config
 managerConfig:
-  env:
-    name: PASSWORD
-    ## User setting: change the password of your Rstudio image
-    value: bioc
   containerPort: 8787
   pullPolicy: IfNotPresent
 
 # worker config
 workerConfig:
-  ## User setting: change the numebr of workers in your cluster
-  workerPoolSize: 5
   env:
     name: master
     value: true
@@ -40,11 +38,15 @@ workerConfig:
 
 # Rstudio specific config
 rstudioConfig:
-  env:
-    name: PASSWORD
-    value: bioc
   type: NodePort
   port: 8787
   nodePort: 30001
   protocol: http
   pullPolicy: IfNotPresent
+
+# user settings
+userSettings:
+  # User setting: change the rstudio password on the manager
+  rstudioPassword: bioc
+  # User setting: change the number of workers in your cluster
+  workerPoolSize: 5


### PR DESCRIPTION
Add the latest version of the helm chart taking into account all the changes.

Bug (avoided by not making a change):

- I've added {{ .Release.Name}} to all the metadata-name sections in the template, except for redis-service.yaml. When I add a release name, the worker doesn't know how to connect to the service it seems like or vice versa resulting in a "CrashBackLoopError" in k8s.
- helm-chart/templates/redis-service.yaml (link to file)
